### PR TITLE
Fix not generating assignments for primitive types in the copy construct...

### DIFF
--- a/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
+++ b/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
@@ -457,6 +457,11 @@ public class BuilderGenerator {
 							body.assign(newField, fieldRef);
 						}
 					}
+				} else {
+					final JPrimitiveType fieldType = (JPrimitiveType) field.type();
+					final JFieldRef newField = JExpr.ref(newObjectVar, field);
+					final JFieldRef fieldRef = otherParam.ref(field);
+					body.assign(newField, fieldRef);
 				}
 			}
 		}


### PR DESCRIPTION
The copy constructor currently ignores primitives field types.  For example given this from an XSD file:

<pre>
&lt;xs:simpleType name="QuantityPerApplication">
  &lt;xs:restriction base="xs:positiveInteger">
    &lt;xs:maxInclusive value="99999999"/>
  &lt;/xs:restriction>
&lt;/xs:simpleType>
&lt;complexType>
  &lt;simpleContent>
    &lt;extension base="&lt;http://www.aftermarket.org>QuantityPerApplication">
      &lt;attribute name="Qualifier" type="{http://www.aftermarket.org}QuantityPerApplicationQualifierType" />
      &lt;attribute name="UOM" use="required">
        &lt;simpleType>
          &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
            &lt;length value="2"/>
          &lt;/restriction>
        &lt;/simpleType>
      &lt;/attribute>
    &lt;/extension>
  &lt;/simpleContent>
&lt;/complexType>
</pre>


I end up with a class that has these fields:

```
    @XmlValue
    protected int value;
    @XmlAttribute(name = "Qualifier")
    protected QuantityPerApplicationQualifierType qualifier;
    @XmlAttribute(name = "UOM", required = true)
    protected String uom;
```

And a Builder constructor of:

```
public Builder(final TParentBuilder parentBuilder, final QuantityPerApplication other, final boolean copy) {
  this._parentBuilder = parentBuilder;
  if (copy) {
    this._product = null;
    this.qualifier = other.qualifier;
    this.uom = other.uom;
  } else {
    this._product = other;
  }
}
```

Which is missing: `this.value = other.value;` so I end up with a default value of 0 for the int.  This patch changes the generated code to be:

```
public Builder(final TParentBuilder parentBuilder, final QuantityPerApplication other, final boolean copy) {
  this._parentBuilder = parentBuilder;
  if (copy) {
    this._product = null;
    this.value = other.value;
    this.qualifier = other.qualifier;
    this.uom = other.uom;
  } else {
    this._product = other;
  }
}
```
