### PR TITLE
Add support for JAXBElement fields in the Fluent API

### DIFF
--- a/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
+++ b/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
@@ -68,6 +68,7 @@ import com.sun.tools.xjc.model.nav.NType;
 import com.sun.xml.bind.v2.model.core.TypeInfo;
 
 import static com.kscs.util.plugins.xjc.base.PluginUtil.nullSafe;
+import javax.xml.bind.JAXBElement;
 
 /**
  * Helper class to generate fluent builder classes in two steps
@@ -347,12 +348,30 @@ class BuilderGenerator {
 			final JMethod withMethod = this.builderClass.raw.method(JMod.PUBLIC, this.builderClass.type, PluginContext.WITH_METHOD_PREFIX + propertyName);
 			final JVar param = withMethod.param(JMod.FINAL, fieldType, fieldName);
 			generateWithMethodJavadoc(withMethod, param);
+			final JFieldVar builderField = this.builderClass.raw.field(JMod.PRIVATE, fieldType, fieldName);
 			if (this.implement) {
-				final JFieldVar builderField = this.builderClass.raw.field(JMod.PRIVATE, fieldType, fieldName);
 				withMethod.body().assign(JExpr._this().ref(builderField), param);
 				withMethod.body()._return(JExpr._this());
 				initBody.assign(productParam.ref(fieldName), JExpr._this().ref(builderField));
 			}
+
+			// If field is a JaxbElement wrapped object, extract wrapped type and instantiate using ObjectMapper
+			if (fieldType instanceof JClass) {
+				final JClass fieldClass = (JClass) fieldType;
+				if (fieldClass.getTypeParameters().size() == 1 && fieldClass.erasure().fullName().equals(JAXBElement.class.getName())) {
+					final JClass innerType = fieldClass.getTypeParameters().get(0);
+					final JMethod withMethodInner = this.builderClass.raw.method(JMod.PUBLIC, this.builderClass.type, PluginContext.WITH_METHOD_PREFIX + propertyName);
+					final JVar paramInner = withMethodInner.param(JMod.FINAL, innerType, fieldName);
+					generateWithMethodJavadoc(withMethodInner, paramInner);
+					if (this.implement) {
+						final JType objectFactory = this.pluginContext.codeModel.ref("ObjectFactory");
+						final JInvocation val = JExpr._new(objectFactory).invoke("create" + this.definedClass.name() + propertyName).arg(param);
+						withMethodInner.body().assign(JExpr._this().ref(builderField), val);
+						withMethodInner.body()._return(JExpr._this());
+					}
+				}
+			}
+
 		} else {
 			final JClass elementType = (JClass)fieldType;
 			final JClass builderFieldElementType = childBuilderOutline.getBuilderClass().narrow(this.builderClass.type);
@@ -464,6 +483,21 @@ class BuilderGenerator {
 				generateBuilderMethodJavadoc(addMethod, "with", superPropertyOutline.getFieldName());
 				if (this.implement) {
 					addMethod.body()._return(JExpr.cast(builderFieldElementType, JExpr._super().invoke(addMethod)));
+				}
+			}
+
+			// If field is a JaxbElement wrapped object, chain with-method in the same was as standard impl above.
+			if (fieldType instanceof JClass) {
+				final JClass fieldClass = (JClass) fieldType;
+				if (fieldClass.getTypeParameters().size() == 1 && fieldClass.erasure().fullName().equals(JAXBElement.class.getName())) {
+					final JClass innerType = fieldClass.getTypeParameters().get(0);
+					final JMethod withMethodInner = this.builderClass.raw.method(JMod.PUBLIC, this.builderClass.type, PluginContext.WITH_METHOD_PREFIX + superPropertyName);
+					final JVar paramInner = withMethodInner.param(JMod.FINAL, innerType, fieldName);
+					generateWithMethodJavadoc(withMethodInner, paramInner);
+					if (this.implement) {
+						withMethodInner.body().invoke(JExpr._super(), PluginContext.WITH_METHOD_PREFIX + superPropertyName).arg(paramInner);
+						withMethodInner.body()._return(JExpr._this());
+					}
 				}
 			}
 		}


### PR DESCRIPTION
JAXB creates quite unnatural code when fields may be 'nil' by wrapping them in JAXBElements. One must then use the (also generated) ObjectFactory to create the right field values.

This Pull Request tries to help by detecting fields with JAXBElement<SomeType> and adding a extra withXxX(SomeType) method that automatically uses ObjectFactory to wrap supplied simple type. This gives the user an option of using a very much simplified syntax that will be much more intuitive.

I hacked this out very quickly today and works well on the WSDL i have at hand, all comments welcome.