### PR TITLE
Improve fluent-builder exception if no Builder class is found.

### DIFF
--- a/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
+++ b/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
@@ -709,7 +709,9 @@ class BuilderGenerator {
 			}
 		}
 		if (superClass != null) {
-			generateExtendsClause(getBuilderDeclaration(superClass.getImplClass()));
+			BuilderOutline superClassBuilder = getBuilderDeclaration(superClass.getImplClass());
+			if (superClassBuilder == null) throw new RuntimeException("Cannot find builder class name " + this.settings.getBuilderClassName().getClassName() + " of: " + superClass.getImplClass());
+			generateExtendsClause(superClassBuilder);
 			if (this.implement) initBody._return(JExpr._super().invoke(initMethod).arg(productParam));
 			generateBuilderMemberOverrides(superClass);
 		} else if (this.implement) {


### PR DESCRIPTION
It took a lot of `System.out.println` statements for me to figure out what was going on :)

I have a `<inheritance:extends>fm.aaia.aces.xml.DigitalFileInformationBase&lt;DigitalFileInformationType&gt;</inheritance:extends>` which is an abstract class (though, just a fancy interface - I just needed to access the protected methods after enabling `-Ximmutable` in `jaxb2-basics`)

This still doesn't fix my issue, but I figured I would at least create a PR for this for anyone elses' benefit.