### PR TITLE
Fixed the links to the plugins in the table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,11 +889,11 @@ Allow property values to be set via property meta information.
 ##### -visitMethodName=`<string>` (visit)
 Name of the method to apply a visitor.
 
-[1]: #constrained-properties
-[2]: #clone
-[3]: #copy
-[4]: #group-contract
-[5]: #immutable
-[6]: #modifier
-[7]: #fluent-builder
-[8]: #meta
+[6]: #constrained-properties
+[4]: #clone
+[5]: #copy
+[3]: #group-contract
+[2]: #immutable
+[8]: #modifier
+[1]: #fluent-builder
+[7]: #meta


### PR DESCRIPTION
Now each link points to the documentation of the corresponding plugin. Since the modifier plugin is not listed in the table of contents, there is no link to it.

Thank you for writing these awesome plugins!